### PR TITLE
Simplifies sum_cell_cell_energies

### DIFF
--- a/tumor_package/energy.py
+++ b/tumor_package/energy.py
@@ -5,31 +5,42 @@ from scipy.spatial.distance import pdist
 
 
 def sum_cell_cell_energies(cell_cell_distances):
-    """
-    Given a list of cell-cell distances, compute the corresponding cell-cell interaction energies and sum those cell-cell interaction energies.
-    Cell-cell interaction energy is strongly repulsive at short distances, weakly attractive at intermediate distances, and zero at long distances
+    """Given a list of cell-cell distances, compute the corresponding
+
+    cell-cell interaction energies and sum those cell-cell interaction
+    energies.  Cell-cell interaction energy is strongly repulsive at
+    short distances, weakly attractive at intermediate distances, and
+    zero at long distances
     """
 
-    Va = 120
-    Vc = 12
+    Va = 120.
+    Vc = 12.
     aa = 1
     bb = 1.2
     cc = 2
     nn = 2
 
-    cond1 = (cell_cell_distances < aa)
-    energy1 = Va * np.sum(np.power(aa / cell_cell_distances[cond1], nn)) - len(cell_cell_distances[cond1]) * float(Vc)
-    cond2 = (~(cell_cell_distances < aa)) & (cell_cell_distances < bb)
-    energy2 = -len(cell_cell_distances[cond2]) * float(Vc)
-    cond3 = (~(cell_cell_distances < bb)) & (cell_cell_distances < cc)
-    energy3 = Vc * np.sum(cell_cell_distances[cond3] - bb) / (cc - bb) - len(cell_cell_distances[cond3]) * float(Vc)
+    cc_dist1 = cell_cell_distances[(cell_cell_distances < aa)]
+    energy1 = Va * np.sum(np.power(aa / cc_dist1, nn))
+    energy1 -= cc_dist1.size * Vc
+
+    cc_dist2 = cell_cell_distances[(~(cell_cell_distances < aa)) &
+                                   (cell_cell_distances < bb)]
+    energy2 = -cc_dist2.size * Vc
+
+    cc_dist3 = cell_cell_distances[(~(cell_cell_distances < bb)) &
+                                   (cell_cell_distances < cc)]
+
+    energy3 = Vc * np.sum(cc_dist3 - bb) / (cc - bb)
+    energy3 -= cc_dist3.size * Vc
 
     return energy1 + energy2 + energy3
 
 
 def calculate_tumor_energy(cells):
-    """
-    Brute-force computation of tumor energy by summing the cell-cell interaction energies of all unique cell pairs
+    """Brute-force computation of tumor energy by summing the cell-cell
+
+    interaction energies of all unique cell pairs
     """
 
     if len(cells) == 0:
@@ -39,5 +50,6 @@ def calculate_tumor_energy(cells):
         return 'undefined'
     else:
         cell_positions = np.array([cell.position for cell in cells])
-        cell_cell_distances = pdist(cell_positions)  # much faster than looping over all unique cell pairs
+        # much faster than looping over all unique cell pairs
+        cell_cell_distances = pdist(cell_positions)
         return sum_cell_cell_energies(cell_cell_distances)

--- a/tumor_package/events.py
+++ b/tumor_package/events.py
@@ -1,4 +1,5 @@
-""" These functions are needed to update a tumor object at every step of the stochastic process """
+""" These functions are needed to update a tumor object at every step
+of the stochastic process """
 
 
 import copy
@@ -11,25 +12,29 @@ from energy import calculate_tumor_energy, sum_cell_cell_energies
 
 
 def time_until_next_event(prng, net_rate):
-    """
-    Compute the time at which the next event is due to occur.
-    All events are modeled as Poisson processes with exponentially distributed waiting times.
-    Units of time are chosen such that the average time it takes for a given cell to divide is 1.
+    """Compute the time at which the next event is due to occur.
+
+    All events are modeled as Poisson processes with exponentially
+    distributed waiting times.  Units of time are chosen such that the
+    average time it takes for a given cell to divide is 1.
     """
 
     return prng.standard_exponential() / net_rate
 
 
-def execute_divisionQuiescence_event(prng, cells, old_tumor_energy, parameterValues):
-    """
-    Randomly choose between dividing a random cell versus making it quiescent.
-    This function modifies the list of cells in place, 
-    but updates the tumor energy using a functional programming style,
-    i.e. the tumor energy is passed in, updated, 
-    and then passed out using a return statement.
+def execute_divisionQuiescence_event(prng, cells,
+                                     old_tumor_energy,
+                                     parameterValues):
+    """Randomly choose between dividing a random cell versus making it
+
+    quiescent.  This function modifies the list of cells in place, but
+    updates the tumor energy using a functional programming style,
+    i.e. the tumor energy is passed in, updated, and then passed out
+    using a return statement.
     """
 
-    # when parent is cloned (cell division), displace parent and daughter this distance from one another
+    # when parent is cloned (cell division), displace parent and daughter this
+    # distance from one another
     distance_between_parent_and_daughter = 1.5
 
     C_cells = [cell for cell in cells if cell.cell_cycle_state == 'cycling']
@@ -37,30 +42,38 @@ def execute_divisionQuiescence_event(prng, cells, old_tumor_energy, parameterVal
 
     Q_cells = [cell for cell in cells if cell.cell_cycle_state == 'quiescent']
 
-    if prng.uniform(0, 1) < self_renewal_probability(random_C_cell, C_cells, Q_cells, parameterValues):
+    if prng.uniform(0, 1) < self_renewal_probability(random_C_cell, C_cells,
+                                                     Q_cells, parameterValues):
         original_parent_position = random_C_cell.position
 
         # randomly displace parent cell
         theta_parent = prng.uniform(0, 2*np.pi)
-        random_C_cell.position = np.add(original_parent_position,
-                                        0.5 * distance_between_parent_and_daughter * np.array([np.cos(theta_parent), np.sin(theta_parent)]))
+        random_C_cell.position = np.add(
+            original_parent_position,
+            0.5 * distance_between_parent_and_daughter *
+            np.array([np.cos(theta_parent), np.sin(theta_parent)]))
 
         # clone parent cell to generate a daughter cell
         daughter_C_cell = copy.deepcopy(random_C_cell)
 
         # randomly displace daughter cell
         theta_daughter = theta_parent + np.pi
-        daughter_C_cell.position = np.add(original_parent_position,
-                                          0.5 * distance_between_parent_and_daughter * np.array([np.cos(theta_daughter), np.sin(theta_daughter)]))
+        daughter_C_cell.position = np.add(
+            original_parent_position,
+            0.5 * distance_between_parent_and_daughter *
+            np.array([np.cos(theta_daughter),
+                      np.sin(theta_daughter)]))
 
         daughter_C_cell.ID = max([cell.ID for cell in cells]) + 1
         cells.append(daughter_C_cell)
 
         def update_tumor_energy():
-            """
-            This updates only the cell-cell interaction energies that actually changed, which scales linearly with the number of cells.
-            That is, it does not wastefully re-compute *all* cell-cell interaction energies,
-            which would scale quadratically with the number of cells.
+            """This updates only the cell-cell interaction energies that
+
+            actually changed, which scales linearly with the number of
+            cells.  That is, it does not wastefully re-compute *all*
+            cell-cell interaction energies, which would scale
+            quadratically with the number of cells.
             """
 
             parent_position = np.array([original_parent_position])
@@ -68,23 +81,35 @@ def execute_divisionQuiescence_event(prng, cells, old_tumor_energy, parameterVal
             daughter2_position = np.array([daughter_C_cell.position])
 
             # use 'is not' not '!=' to check object identity:
-            other_cells = [cell for cell in cells if (cell is not random_C_cell) and (cell is not daughter_C_cell)]
+            other_cells = [cell for cell in cells
+                           if (cell is not random_C_cell) and
+                           (cell is not daughter_C_cell)]
             other_positions = np.array([cell.position for cell in other_cells])
 
-            parent_other_distances = cdist(parent_position, other_positions).ravel()
-            parent_other_energy = sum_cell_cell_energies(parent_other_distances)
+            parent_other_distances = cdist(parent_position,
+                                           other_positions).ravel()
+            parent_other_energy = sum_cell_cell_energies(
+                parent_other_distances)
 
-            daughter1_other_distances = cdist(daughter1_position, other_positions).ravel()
-            daughter1_other_energy = sum_cell_cell_energies(daughter1_other_distances)
+            daughter1_other_distances = cdist(daughter1_position,
+                                              other_positions).ravel()
+            daughter1_other_energy = sum_cell_cell_energies(
+                daughter1_other_distances)
 
-            daughter2_other_distances = cdist(daughter2_position, other_positions).ravel()
-            daughter2_other_energy = sum_cell_cell_energies(daughter2_other_distances)
+            daughter2_other_distances = cdist(daughter2_position,
+                                              other_positions).ravel()
+            daughter2_other_energy = sum_cell_cell_energies(
+                daughter2_other_distances)
 
-            daughter1_daughter2_distance = cdist(daughter1_position, daughter2_position).ravel()
-            daughter1_daughter2_energy = sum_cell_cell_energies(daughter1_daughter2_distance)
+            daughter1_daughter2_distance = cdist(daughter1_position,
+                                                 daughter2_position).ravel()
+            daughter1_daughter2_energy = sum_cell_cell_energies(
+                daughter1_daughter2_distance)
 
-            return (old_tumor_energy - parent_other_energy + daughter1_other_energy
-                    + daughter2_other_energy + daughter1_daughter2_energy)
+            return (old_tumor_energy - parent_other_energy +
+                    daughter1_other_energy +
+                    daughter2_other_energy +
+                    daughter1_daughter2_energy)
 
         if len(cells) > 2:
             return update_tumor_energy()
@@ -201,4 +226,3 @@ def execute_death_event(prng, cells, old_tumor_energy):
         return update_tumor_energy()
     else:
         return 'undefined'
-


### PR DESCRIPTION
I only made significant changes in `energy.py`, where I just factorized the distance filtering calls, e.g. 

``` python
cc_dist1 = cell_cell_distances[(cell_cell_distances < aa)]
```

instead of

``` python
cond1 = (cell_cell_distances < aa)
energy_function(cell_cell_distances[cond1])
```

The notebook runs fine.

Modifications to `events.py` are just [PEP8](http://pep8.org/) compliance modifications.
About `events.py`:
- Unless you have a really good reason for it, it might not be a good idea to define a function inside another. It is better to pass arguments (defining a function has a cost, and there might be optimisations between calls)
-  You make repeated calls to `sum_cell_cell_energies()`. It might be better to concatenate all the distances and call it only once.
